### PR TITLE
Added image and version variable & resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ module "terraform-cloud-agent-kubernetes" {
 
   namespace          = "terraform-cloud-agent"
   create_namespace   = true
-  agent_token_name   = "example-agent"
-  agent_token_secret = "myagent.atlasv1.secrettoken"
+  agent_name   = "example-agent"
+  agent_token        = "myagent.atlasv1.secrettoken"
   cluster_access     = true
 }
 ```

--- a/kubernetes_cluster_role.tf
+++ b/kubernetes_cluster_role.tf
@@ -12,8 +12,8 @@ resource "kubernetes_cluster_role" "tfc_agent_role" {
   }
 
   rule {
-    api_groups = ["", "apps", "autoscaling", "batch", "extensions", "policy", "rbac.authorization.k8s.io", "cilium.io"]
-    resources  = ["componentstatuses", "configmaps", "daemonsets", "deployments", "events", "endpoints", "horizontalpodautoscalers", "ingress", "jobs", "limitranges", "namespaces", "nodes", "pods", "persistentvolumes", "persistentvolumeclaims", "resourcequotas", "replicasets", "replicationcontrollers", "serviceaccounts", "services", "ciliumnetworkpolicies", "ciliumclusterwidenetworkpolicies"]
+    api_groups = concat(["", "apps", "autoscaling", "batch", "extensions", "policy", "rbac.authorization.k8s.io"], var.cluster_access_rbac_api_groups)
+    resources  = concat(["componentstatuses", "configmaps", "daemonsets", "deployments", "events", "endpoints", "horizontalpodautoscalers", "ingress", "jobs", "limitranges", "namespaces", "nodes", "pods", "persistentvolumes", "persistentvolumeclaims", "resourcequotas", "replicasets", "replicationcontrollers", "serviceaccounts", "services"], var.cluster_access_rbac_resources)
     verbs      = ["*"]
   }
 }

--- a/kubernetes_cluster_role.tf
+++ b/kubernetes_cluster_role.tf
@@ -12,8 +12,8 @@ resource "kubernetes_cluster_role" "tfc_agent_role" {
   }
 
   rule {
-    api_groups = ["", "apps", "autoscaling", "batch", "extensions", "policy", "rbac.authorization.k8s.io"]
-    resources  = ["componentstatuses", "configmaps", "daemonsets", "deployments", "events", "endpoints", "horizontalpodautoscalers", "ingress", "jobs", "limitranges", "namespaces", "nodes", "pods", "persistentvolumes", "persistentvolumeclaims", "resourcequotas", "replicasets", "replicationcontrollers", "serviceaccounts", "services"]
+    api_groups = ["", "apps", "autoscaling", "batch", "extensions", "policy", "rbac.authorization.k8s.io", "cilium.io"]
+    resources  = ["componentstatuses", "configmaps", "daemonsets", "deployments", "events", "endpoints", "horizontalpodautoscalers", "ingress", "jobs", "limitranges", "namespaces", "nodes", "pods", "persistentvolumes", "persistentvolumeclaims", "resourcequotas", "replicasets", "replicationcontrollers", "serviceaccounts", "services", "ciliumnetworkpolicies", "ciliumclusterwidenetworkpolicies"]
     verbs      = ["*"]
   }
 }

--- a/kubernetes_config_map.tf
+++ b/kubernetes_config_map.tf
@@ -11,7 +11,7 @@ resource "kubernetes_config_map" "tfc_agent_configuration" {
   }
 
   data = {
-    name           = var.agent_token_name
+    name           = var.agent_name
     url            = var.tfc_url
     log-level      = var.agent_log_level
     disable-update = tostring(var.agent_disable_update)

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -11,7 +11,7 @@ resource "kubernetes_deployment" "tfc_agent" {
   }
 
   spec {
-    replicas = 1
+    replicas = var.agent_replicacount
 
     selector {
       match_labels = {
@@ -24,7 +24,7 @@ resource "kubernetes_deployment" "tfc_agent" {
       metadata {
         labels = {
           "app.kubernetes.io/name"           = "terraform-cloud-agent"
-          "app.kubernetes.io/version"        = local.version
+          "app.kubernetes.io/version"        = var.agent_version
           "app.kubernetes.io/module-version" = local.module-version
           "app.kubernetes.io/managed-by"     = "terraform"
         }
@@ -32,7 +32,7 @@ resource "kubernetes_deployment" "tfc_agent" {
 
       spec {
         container {
-          image = "hashicorp/tfc-agent:${local.version}"
+          image = "${var.agent_image}:${var.agent_version}"
           name  = "terraform-cloud-agent"
 
           #   resources {

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -34,16 +34,6 @@ resource "kubernetes_deployment" "tfc_agent" {
         container {
           image = "${var.agent_image}:${var.agent_version}"
           name  = "terraform-cloud-agent"
-          resources {
-            requests = {
-              cpu    = var.requests_cpu
-              memory = var.requests_memory
-            }
-            limits = {
-              cpu    = var.limits_cpu
-              memory = var.limits_memory
-            }
-          }
           env {
             name = "TFC_AGENT_TOKEN"
             value_from {
@@ -91,6 +81,16 @@ resource "kubernetes_deployment" "tfc_agent" {
                 name = kubernetes_config_map.tfc_agent_configuration.metadata[0].name
                 key  = "disable-update"
               }
+            }
+          }
+          resources {
+            requests = {
+              cpu    = var.requests_cpu
+              memory = var.requests_memory
+            }
+            limits = {
+              cpu    = var.limits_cpu
+              memory = var.limits_memory
             }
           }
         }

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -34,18 +34,16 @@ resource "kubernetes_deployment" "tfc_agent" {
         container {
           image = "${var.agent_image}:${var.agent_version}"
           name  = "terraform-cloud-agent"
-
-          #   resources {
-          #     requests {
-          #       cpu    = "2000m"
-          #       memory = "2Gi"
-          #     }
-          #     limits {
-          #       cpu    = "8000m"
-          #       memory = "8Gi"
-          #     }
-          #   }
-
+          resources {
+            requests = {
+              cpu    = var.requests_cpu
+              memory = var.requests_memory
+            }
+            limits = {
+              cpu    = var.limits_cpu
+              memory = var.limits_memory
+            }
+          }
           env {
             name = "TFC_AGENT_TOKEN"
             value_from {

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -11,7 +11,7 @@ resource "kubernetes_deployment" "tfc_agent" {
   }
 
   spec {
-    replicas = var.agent_replicacount
+    replicas = var.agent_replicas
 
     selector {
       match_labels = {

--- a/kubernetes_secret.tf
+++ b/kubernetes_secret.tf
@@ -11,6 +11,6 @@ resource "kubernetes_secret" "tfc_agent_token" {
   }
 
   data = {
-    "token" = var.agent_token_secret
+    "token" = var.agent_token
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 locals {
-  version        = "0.1.4"
   module-version = "0.0.3"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  module-version = "0.0.3"
+  module-version = "0.0.4"
 }
 
 terraform {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,3 @@
 locals {
-  module-version = "0.0.4"
+  module-version = "0.1.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
 locals {
   module-version = "0.0.5"
 }
-
-terraform {
-  required_version = ">= 0.14"
-}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  module-version = "0.0.4"
+  module-version = "0.0.5"
 }
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,3 @@
 locals {
-  module-version = "0.0.5"
+  module-version = "0.0.4"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "create_namespace" {
 
 variable "limits_cpu" {
   type        = string
-  default     = "1"
+  default     = "2"
   description = "CPU hard limits."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
-variable "agent_token_name" {
+variable "agent_name" {
   type        = string
   description = "The TFC agent token description defined in TFC at app/<org>/settings/agents."
 }
 
-variable "agent_token_secret" {
+variable "agent_token" {
   type        = string
-  description = "The TFC agent token secret generated when the agent was created."
+  description = "The TFC agent token generated when the agent was created."
 }
 
 variable "tfc_url" {
@@ -20,10 +20,28 @@ variable "agent_log_level" {
   description = "Available log levels are info, error, warn, debug, and trace."
 }
 
+variable "agent_image" {
+  type        = string
+  default     = "hashicorp/tfc-agent"
+  description = "Name of the Terraform Cloud Agent docker image."
+}
+
+variable "agent_version" {
+  type        = string
+  default     = "latest"
+  description = "Version of the Terraform Cloud Agent docker image."
+}
+
 variable "agent_disable_update" {
   type        = bool
   default     = true
   description = "Agents will self-update if set to false."
+}
+
+variable "agent_replicacount" {
+  type        = number
+  default     = 1
+  description = "Replicacount of the terraform cloud agent deployment."
 }
 
 variable "namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,13 +46,13 @@ variable "cluster_access" {
 }
 
 variable "cluster_access_rbac_api_groups" {
-  type        = string
+  type        = list(string)
   default     = null
   description = "Additional rbac api groups for the rbac role"
 }
 
 variable "cluster_access_rbac_resources" {
-  type        = string
+  type        = list(string)
   default     = null
   description = "Additional rbac resources for the rbac role"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "agent_name" {
   description = "The TFC agent token description defined in TFC at app/<org>/settings/agents."
 }
 
-variable "agent_replicacount" {
+variable "agent_replicas" {
   type        = number
   default     = 1
   description = "Replicacount of the terraform cloud agent deployment."

--- a/variables.tf
+++ b/variables.tf
@@ -47,13 +47,13 @@ variable "cluster_access" {
 
 variable "cluster_access_rbac_api_groups" {
   type        = list(string)
-  default     = null
+  default     = []
   description = "Additional rbac api groups for the rbac role"
 }
 
 variable "cluster_access_rbac_resources" {
   type        = list(string)
-  default     = null
+  default     = []
   description = "Additional rbac resources for the rbac role"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "limits_cpu" {
 
 variable "limits_memory" {
   type        = string
-  default     = "250Mi"
+  default     = "2Gi"
   description = "Memory hard limits."
 }
 
@@ -69,13 +69,13 @@ variable "namespace" {
 
 variable "requests_cpu" {
   type        = string
-  default     = "250m"
+  default     = "500m"
   description = "CPU requests."
 }
 
 variable "requests_memory" {
   type        = string
-  default     = "50Mi"
+  default     = "250Mi"
   description = "Memory requests."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,7 @@
-variable "agent_name" {
-  type        = string
-  description = "The TFC agent token description defined in TFC at app/<org>/settings/agents."
-}
-
-variable "agent_token" {
-  type        = string
-  description = "The TFC agent token generated when the agent was created."
-}
-
-variable "tfc_url" {
-  type        = string
-  default     = "https://app.terraform.io"
-  description = "The Terraform Cloud endpoint.  Must be changed if using Terraform Enterprise."
-}
-
-variable "agent_log_level" {
-  type        = string
-  default     = "error"
-  description = "Available log levels are info, error, warn, debug, and trace."
+variable "agent_disable_update" {
+  type        = bool
+  default     = true
+  description = "Agents will self-update if set to false."
 }
 
 variable "agent_image" {
@@ -26,16 +10,15 @@ variable "agent_image" {
   description = "Name of the Terraform Cloud Agent docker image."
 }
 
-variable "agent_version" {
+variable "agent_log_level" {
   type        = string
-  default     = "latest"
-  description = "Version of the Terraform Cloud Agent docker image."
+  default     = "error"
+  description = "Available log levels are info, error, warn, debug, and trace."
 }
 
-variable "agent_disable_update" {
-  type        = bool
-  default     = true
-  description = "Agents will self-update if set to false."
+variable "agent_name" {
+  type        = string
+  description = "The TFC agent token description defined in TFC at app/<org>/settings/agents."
 }
 
 variable "agent_replicacount" {
@@ -44,9 +27,15 @@ variable "agent_replicacount" {
   description = "Replicacount of the terraform cloud agent deployment."
 }
 
-variable "namespace" {
+variable "agent_token" {
   type        = string
-  description = "The namespace to deploy the agent into.  Unless create_namespace is true, the namespace must already exist."
+  description = "The TFC agent token generated when the agent was created."
+}
+
+variable "agent_version" {
+  type        = string
+  default     = "latest"
+  description = "Version of the Terraform Cloud Agent docker image."
 }
 
 variable "cluster_access" {
@@ -60,3 +49,39 @@ variable "create_namespace" {
   default     = false
   description = "When true, creates the namespace for the Terraform Cloud Agent."
 }
+
+variable "limits_cpu" {
+  type        = string
+  default     = "1000m"
+  description = "CPU hard limits."
+}
+
+variable "limits_memory" {
+  type        = string
+  default     = "1Gb"
+  description = "Memory hard limits."
+}
+
+variable "namespace" {
+  type        = string
+  description = "The namespace to deploy the agent into.  Unless create_namespace is true, the namespace must already exist."
+}
+
+variable "requests_cpu" {
+  type        = string
+  default     = "1"
+  description = "CPU requests."
+}
+
+variable "requests_memory" {
+  type        = string
+  default     = "1Gb"
+  description = "Memory requests."
+}
+
+variable "tfc_url" {
+  type        = string
+  default     = "https://app.terraform.io"
+  description = "The Terraform Cloud endpoint.  Must be changed if using Terraform Enterprise."
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,7 @@ variable "agent_replicas" {
 variable "agent_token" {
   type        = string
   description = "The TFC agent token generated when the agent was created."
+  sensitive   = true
 }
 
 variable "agent_version" {
@@ -42,6 +43,18 @@ variable "cluster_access" {
   type        = bool
   default     = false
   description = "When true, provides the agent access to the cluster to manage Kubernetes resources."
+}
+
+variable "cluster_access_rbac_api_groups" {
+  type        = string
+  default     = null
+  description = "Additional rbac api groups for the rbac role"
+}
+
+variable "cluster_access_rbac_resources" {
+  type        = string
+  default     = null
+  description = "Additional rbac resources for the rbac role"
 }
 
 variable "create_namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,13 +52,13 @@ variable "create_namespace" {
 
 variable "limits_cpu" {
   type        = string
-  default     = "1000m"
+  default     = "1"
   description = "CPU hard limits."
 }
 
 variable "limits_memory" {
   type        = string
-  default     = "1Gb"
+  default     = "250Mi"
   description = "Memory hard limits."
 }
 
@@ -69,13 +69,13 @@ variable "namespace" {
 
 variable "requests_cpu" {
   type        = string
-  default     = "1"
+  default     = "250m"
   description = "CPU requests."
 }
 
 variable "requests_memory" {
   type        = string
-  default     = "1Gb"
+  default     = "50Mi"
   description = "Memory requests."
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      version = ">= 2.0.0"
+    }
+  }
+
+  required_version = ">= 0.14"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
     kubernetes = {
+      source  = "hashicorp/kubernetes"
       version = ">= 2.0.0"
     }
   }


### PR DESCRIPTION
minor changes: 
- Changed token var names to pass tfsec security check
- Added image and version variables so an image on ecr can be used
- enable/added vars to set resource limits
- added option to pass extra resources to the rbac profile of the service account